### PR TITLE
Fixed select options appearing white-on-white

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -9,6 +9,14 @@
   font-weight: bold !important;
 }
 
+select {
+  color: #9B9B9B;
+}
+
+select option {
+  color: #9B9B9B;
+}
+
 .acceptinvitecontroller {
   letter-spacing: -.3px;
 }
@@ -417,7 +425,6 @@ h1, h3 {
 .school-year-select select {
    background: transparent;
    width: 100%;
-   color: #9B9B9B;
    padding: 5px;
    font-size: 14px;
    font-weight: 600 !important;


### PR DESCRIPTION
During registration, I noticed the select option fields were displaying white text on a white background. I reproduced this on the live site with some JavaScript wizardry:

![Can't see fields](http://i.imgur.com/MP7TvOQ.gif)

The fix: 

![Can now see fields](http://i.imgur.com/Vcbckxo.gif)

Because the `*` selector targets all elements, the default text color for the `select` element (and its `option` children) was white, on a white background (on Windows/Firefox/Chrome). This commit corrects the colors to match the grey color used in other form elements.

The `.school-year-select select` `color` property was removed because this change makes it redundant.
